### PR TITLE
Add Environment Command (#2152)

### DIFF
--- a/pkg/cmd/component/component/add.go
+++ b/pkg/cmd/component/component/add.go
@@ -19,7 +19,8 @@ import (
 
 const (
 	// AddCompRecommendedCommandName the recommended command name
-	AddCompRecommendedCommandName = "add"
+	AddCompRecommendedCommandName      = "add"
+	ApplicationNameAddComponentMessage = "Provide the Application name to add a Component"
 )
 
 // AddCompParameters encapsulates the parameters for the kam pipelines init command.
@@ -133,15 +134,15 @@ func initiateInteractiveModeComponent(io *AddCompParameters, cmd *cobra.Command)
 		err := ui.ValidateName(io.ApplicationName)
 		if err != nil {
 			log.Progressf("%v", err)
-			io.ApplicationName = ui.SelectApplicationNameComp("add")
+			io.ApplicationName = ui.SelectApplicationNameComp(ApplicationNameAddComponentMessage)
 		}
 		exists, _ := ioutils.IsExisting(appFs, filepath.Join(io.Output, io.ApplicationName))
 		if !exists {
 			log.Progressf("the Application : %s doesn't exists in Path %s", io.ApplicationName, io.Output)
-			io.ApplicationName = ui.SelectApplicationNameComp("add")
+			io.ApplicationName = ui.SelectApplicationNameComp(ApplicationNameAddComponentMessage)
 		}
 	} else {
-		io.ApplicationName = ui.SelectApplicationNameComp("add")
+		io.ApplicationName = ui.SelectApplicationNameComp(ApplicationNameAddComponentMessage)
 	}
 	ui.AppNameGiven = io.ApplicationName
 

--- a/pkg/cmd/component/component/delete.go
+++ b/pkg/cmd/component/component/delete.go
@@ -16,7 +16,8 @@ import (
 )
 
 const (
-	DeleteCompRecommendedCommandName = "delete"
+	DeleteCompRecommendedCommandName      = "delete"
+	ApplicationNameDeleteComponentMessage = "Provide the Application name for which to delete a component"
 )
 
 type DeleteCompParameters struct {
@@ -108,15 +109,15 @@ func initiateInteractiveModeDeleteComponent(io *DeleteCompParameters, cmd *cobra
 		err := ui.ValidateName(io.ApplicationName)
 		if err != nil {
 			log.Progressf("%v", err)
-			io.ApplicationName = ui.SelectApplicationNameComp("delete")
+			io.ApplicationName = ui.SelectApplicationNameComp(ApplicationNameDeleteComponentMessage)
 		}
 		exists, _ := ioutils.IsExisting(appFS, filepath.Join(io.Output, io.ApplicationName))
 		if !exists {
 			log.Progressf("the Application : %s doesn't exists in Path %s", io.ApplicationName, io.Output)
-			io.ApplicationName = ui.SelectApplicationNameComp("delete")
+			io.ApplicationName = ui.SelectApplicationNameComp(ApplicationNameDeleteComponentMessage)
 		}
 	} else {
-		io.ApplicationName = ui.SelectApplicationNameComp("delete")
+		io.ApplicationName = ui.SelectApplicationNameComp(ApplicationNameDeleteComponentMessage)
 	}
 	ui.AppNameGiven = io.ApplicationName
 	presentComponents := ui.NumberOfComponents(filepath.Join(io.Output, io.ApplicationName, "components"))

--- a/pkg/cmd/component/environment/add.go
+++ b/pkg/cmd/component/environment/add.go
@@ -1,0 +1,247 @@
+package env
+
+import (
+	"fmt"
+	"github.com/redhat-developer/kam/pkg/cmd/component/cmd/ui"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/openshift/odo/pkg/log"
+	"github.com/redhat-developer/kam/pkg/cmd/genericclioptions"
+	component "github.com/redhat-developer/kam/pkg/pipelines/component"
+	hpipelines "github.com/redhat-developer/kam/pkg/pipelines/component"
+	env "github.com/redhat-developer/kam/pkg/pipelines/component/environment"
+	"github.com/redhat-developer/kam/pkg/pipelines/ioutils"
+	"github.com/spf13/cobra"
+
+	ktemplates "k8s.io/kubectl/pkg/util/templates"
+)
+
+const (
+	// AddEnvRecommendedCommandName the recommended command name
+	AddEnvRecommendedCommandName = "add"
+	componentNameFlag            = "component-name"
+	outputFolderNameFlag         = "output"
+	applicationNameFlag          = "application-name"
+	environmentNameFlag          = "env-name"
+
+	ApplicationNameAddEnvironmentMessage = "Provide the Application name to add an Environment"
+)
+
+var (
+	addEnvExample = ktemplates.Examples(`
+	# Add a new environment to the application's component in the GitOps repository
+	# Example: kam env add --output <path to Application folder> --application-name <Application name> --component-name <component name> --env-name <environment name>
+	
+	%[1]s 
+	`)
+
+	addEnvLongDesc  = ktemplates.LongDesc(`Add a new environment to the application's component in the GitOps repository`)
+	addEnvShortDesc = `Add a new environment`
+)
+
+// AddEnvParameters encapsulates the parameters for the kam pipelines init command.
+type AddEnvParameters struct {
+	*hpipelines.GeneratorOptions
+	Interactive bool
+}
+
+// NewAddEnvParameters bootstraps a AddEnvParameters instance.
+func NewAddEnvParameters() *AddEnvParameters {
+	return &AddEnvParameters{
+		GeneratorOptions: &hpipelines.GeneratorOptions{},
+	}
+}
+
+// Checking the mandatory flags & reusing missingFlagErr in .go
+func checkMandatoryFlags(flags map[string]string) error {
+	missingFlags := []string{}
+	mandatoryFlags := []string{componentNameFlag, applicationNameFlag, environmentNameFlag}
+	for _, flag := range mandatoryFlags {
+		if flags[flag] == "" {
+			missingFlags = append(missingFlags, fmt.Sprintf("%q", flag))
+		}
+	}
+	if len(missingFlags) > 0 {
+		return missingFlagErr(missingFlags)
+	}
+	return nil
+}
+
+func missingFlagErr(flags []string) error {
+	return fmt.Errorf("required flag(s) %s not set", strings.Join(flags, ", "))
+}
+
+func initiateNonInteractiveModeComponent(io *AddEnvParameters) error {
+	appFs := ioutils.NewFilesystem()
+	mandatoryFlags := map[string]string{componentNameFlag: io.ComponentName, applicationNameFlag: io.ApplicationName, environmentNameFlag: io.EnvironmentName}
+	if err := checkMandatoryFlags(mandatoryFlags); err != nil {
+		return err
+	}
+	err := ui.ValidateName(io.ApplicationName)
+	if err != nil {
+		return err
+	}
+	err = ui.ValidateName(io.ComponentName)
+	if err != nil {
+		return err
+	}
+	if io.Output == "." {
+		path, _ := os.Getwd()
+		io.Output = path
+	}
+	exists, _ := ioutils.IsExisting(appFs, io.Output)
+	if !exists {
+		return fmt.Errorf("the provided path  %s does not exist. ", io.Output)
+	}
+	exists, _ = ioutils.IsExisting(appFs, filepath.Join(io.Output, io.ApplicationName))
+	if !exists {
+		return fmt.Errorf("the %s application doesn't exist in the path: %s", io.ApplicationName, io.Output)
+	}
+	exists, _ = ioutils.IsExisting(appFs, filepath.Join(io.Output, io.ApplicationName, "components", io.ComponentName))
+	if !exists {
+		return fmt.Errorf("the %s component doesn't exist in path %s", io.ComponentName, filepath.Join(io.Output, io.ApplicationName, "components", io.ComponentName))
+	}
+	exists, _ = ioutils.IsExisting(appFs, filepath.Join(io.Output, io.ApplicationName, "components", io.ComponentName, "overlays", io.EnvironmentName))
+	if exists {
+		return fmt.Errorf("the %s environment already exists. Choose a different environment name", io.EnvironmentName)
+	}
+	return nil
+}
+
+func initiateInteractiveModeComponent(io *AddEnvParameters, cmd *cobra.Command) error {
+	appFs := ioutils.NewFilesystem()
+	log.Progressf("\nStarting interactive prompt\n")
+	useDefaultValues := !ui.UseDefaultValuesComponent()
+	if !cmd.Flag("output").Changed && useDefaultValues {
+		io.Output = ui.ComponentOutputPath()
+	}
+	if io.Output == "./" {
+		promp := !ui.UseDefaultValuesComponent()
+		if promp {
+			// ask for output folder
+			io.Output = ui.ComponentOutputPath()
+		}
+	}
+	if io.Output != "" {
+		exists, _ := ioutils.IsExisting(appFs, io.Output)
+		if !exists {
+			log.Progressf("the provided Path doesn't exists in you directory : %s", io.Output)
+			io.Output = ui.ComponentOutputPath()
+			// ask for output folder
+		}
+	}
+	if io.Output == "./" || io.Output == "." {
+		path, _ := os.Getwd()
+		io.Output = path
+	}
+	ui.PathGiven = io.Output
+	if io.ApplicationName != "" {
+		err := ui.ValidateName(io.ApplicationName)
+		if err != nil {
+			log.Progressf("%v", err)
+			io.ApplicationName = ui.SelectApplicationNameComp(ApplicationNameAddEnvironmentMessage)
+		} else {
+			exists, _ := ioutils.IsExisting(appFs, filepath.Join(io.Output, io.ApplicationName))
+			if !exists {
+				log.Progressf("the Application : %s doesn't exists in Path %s", io.ApplicationName, io.Output)
+				io.ApplicationName = ui.SelectApplicationNameComp(ApplicationNameAddEnvironmentMessage)
+			}
+		}
+	} else {
+		io.ApplicationName = ui.SelectApplicationNameComp(ApplicationNameAddEnvironmentMessage)
+	}
+	ui.AppNameGiven = io.ApplicationName
+	presentComponents := ui.NumberOfComponents(filepath.Join(io.Output, io.ApplicationName, "components"))
+	if len(presentComponents) == 0 {
+		return fmt.Errorf("there are no components in the %s application in folder: %s ", io.ApplicationName, io.Output)
+	} else {
+		if io.ComponentName != "" {
+			err := ui.ValidateName(io.ComponentName)
+			if err != nil {
+				log.Progressf("%v", err)
+				io.ComponentName = ui.SelectComponentNameDelete(filepath.Join(io.Output, io.ApplicationName, "components"))
+			}
+			exists, _ := ioutils.IsExisting(appFs, filepath.Join(io.Output, io.ApplicationName, "components", io.ComponentName))
+			if !exists {
+				log.Errorf("the component : %s does not exists in Application : %s at %s ", io.ComponentName, io.ApplicationName, io.Output)
+				io.ComponentName = ui.SelectComponentNameDelete(filepath.Join(io.Output, io.ApplicationName, "components"))
+			}
+		} else {
+			io.ComponentName = ui.SelectComponentNameDelete(filepath.Join(io.Output, io.ApplicationName, "components"))
+		}
+	}
+	ui.ComponentNameGiven = io.ComponentName
+	if io.EnvironmentName != "" {
+		err := ui.ValidateName(io.EnvironmentName)
+		if err != nil {
+			log.Progressf("%v", err)
+			io.EnvironmentName = ui.AddEnvironmentName()
+		}
+		exists, _ := ioutils.IsExisting(appFs, filepath.Join(io.Output, io.ApplicationName, "components", io.ComponentName, "overlays", io.EnvironmentName))
+		if exists {
+			io.EnvironmentName = ui.AddEnvironmentName()
+		}
+	} else {
+		io.EnvironmentName = ui.AddEnvironmentName()
+	}
+
+	return nil
+}
+
+// Complete completes AddEnvParameters after they've been created.
+//
+// If the prefix provided doesn't have a "-" then one is added, this makes the
+// generated environment names nicer to read.
+func (eo *AddEnvParameters) Complete(name string, cmd *cobra.Command, args []string) error {
+	if cmd.Flags().NFlag() == 0 || eo.Interactive {
+		return initiateInteractiveModeComponent(eo, cmd)
+	}
+	return initiateNonInteractiveModeComponent(eo)
+}
+
+// Validate validates the parameters of the EnvParameters.
+func (eo *AddEnvParameters) Validate() error {
+	return nil
+}
+
+// Run runs the project bootstrap command.
+func (eo *AddEnvParameters) Run() error {
+	appFs := ioutils.NewFilesystem()
+	options := component.GeneratorOptions{
+		ComponentName:   eo.ComponentName,
+		ApplicationName: eo.ApplicationName,
+		Output:          eo.Output,
+		EnvironmentName: eo.EnvironmentName,
+	}
+	err := env.AddEnv(&options, appFs)
+	if err != nil {
+		return err
+	}
+	log.Successf("Created %s environment successfully. Check the deployment-patch.yaml to further customize.", eo.EnvironmentName)
+	return nil
+}
+
+// NewCmdAddEnv creates the project add environment command.
+func NewCmdAddEnv(name, fullName string) *cobra.Command {
+	o := NewAddEnvParameters()
+
+	addEnvCmd := &cobra.Command{
+		Use:     name,
+		Short:   addEnvShortDesc,
+		Long:    addEnvLongDesc,
+		Example: fmt.Sprintf(addEnvExample, fullName),
+		Run: func(cmd *cobra.Command, args []string) {
+			genericclioptions.GenericRun(o, cmd, args)
+		},
+	}
+
+	addEnvCmd.Flags().StringVar(&o.EnvironmentName, "env-name", "", "Name of the environment/namespace")
+	addEnvCmd.Flags().StringVar(&o.Output, "output", ".", "Folder path to the Application to add a new environment")
+	addEnvCmd.Flags().StringVar(&o.ComponentName, "component-name", "", "Name of the component to add the environment")
+	addEnvCmd.Flags().BoolVar(&o.Interactive, "interactive", false, "If true, enable prompting for most options if not already specified on the command line")
+	addEnvCmd.Flags().StringVar(&o.ApplicationName, "application-name", "", "Name of the Application to add the environment")
+
+	return addEnvCmd
+}

--- a/pkg/cmd/component/environment/add_test.go
+++ b/pkg/cmd/component/environment/add_test.go
@@ -1,0 +1,45 @@
+package env
+
+import "testing"
+
+// Test case for checking the input flags.
+func TestMissingFlagsComponent(t *testing.T) {
+	tests := []struct {
+		desc  string
+		flags map[string]string
+		err   error
+	}{
+		{
+			"Required flags are present",
+			map[string]string{"component-name": "value-1", "application-name": "value-2", "env-name": "value-3"},
+			nil,
+		},
+		{
+			"A required flag is absent",
+			map[string]string{"component-name": "value-1", "application-name": "value-2"},
+			missingFlagErr([]string{`"env-name"`}),
+		},
+		{
+			"A required flag is absent",
+			map[string]string{"component-name": "value-1", "application-name": "value-2", "env-name": ""},
+			missingFlagErr([]string{`"env-name"`}),
+		},
+		{
+			"Multiple required flags are absent",
+			map[string]string{"component-name": "", "application-name": "", "env-name": ""},
+			missingFlagErr([]string{`"component-name"`, `"application-name"`, `"env-name"`}),
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.desc, func(t *testing.T) {
+			gotErr := checkMandatoryFlags(test.flags)
+			if gotErr != nil && test.err != nil {
+				if gotErr.Error() != test.err.Error() {
+					t.Fatalf("error mismatch: got %v, want %v", gotErr, test.err)
+				}
+			} else if gotErr != test.err {
+				t.Fatalf("error mismatch: got %v, want %v", gotErr, test.err)
+			}
+		})
+	}
+}

--- a/pkg/cmd/component/environment/environment.go
+++ b/pkg/cmd/component/environment/environment.go
@@ -1,0 +1,33 @@
+package env
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/redhat-developer/kam/pkg/cmd/utility"
+	"github.com/spf13/cobra"
+)
+
+// EnvRecommendedCommandName is the recommended environment command name.
+const EnvRecommendedCommandName = "env"
+
+// NewCmdEnv create a new environment command
+func NewCmdEnv(name, fullName string) *cobra.Command {
+
+	addEnvCmd := NewCmdAddEnv(AddEnvRecommendedCommandName, utility.GetFullName(fullName, AddEnvRecommendedCommandName))
+	var envCmd = &cobra.Command{
+		Use:   name,
+		Short: "Manage an environment in GitOps",
+		Example: fmt.Sprintf("%s\n%s\n\n  See sub-commands individually for more examples",
+			fullName, "kam env add --output <path to Application folder> --application-name <Application name> --component-name <component name> --env-name <environment name>"),
+		Run: func(cmd *cobra.Command, args []string) {
+			if len(args) == 0 {
+				cmd.Help()
+				os.Exit(0)
+			}
+		},
+	}
+	envCmd.AddCommand(addEnvCmd)
+	envCmd.Annotations = map[string]string{"command": "main"}
+	return envCmd
+}

--- a/pkg/cmd/kam.go
+++ b/pkg/cmd/kam.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	env "github.com/redhat-developer/kam/pkg/cmd/component/environment"
 	"log"
 
 	bootstrapnew "github.com/redhat-developer/kam/pkg/cmd/component"
@@ -38,6 +39,7 @@ func MakeRootCmd() *cobra.Command {
 		completionCmd,
 		bootstrapnew.NewCmdBootstrapNew(bootstrapnew.BootstrapRecommendedCommandName, utility.GetFullName(fullName, bootstrapnew.BootstrapRecommendedCommandName)),
 		component.NewCmdComp(component.CompRecommendedCommandName, utility.GetFullName(fullName, component.CompRecommendedCommandName)),
+		env.NewCmdEnv(env.EnvRecommendedCommandName, utility.GetFullName(fullName, env.EnvRecommendedCommandName)),
 	)
 	return rootCmd
 }

--- a/pkg/pipelines/component/environment/environment.go
+++ b/pkg/pipelines/component/environment/environment.go
@@ -1,0 +1,39 @@
+package environment
+
+import (
+	"fmt"
+	"github.com/redhat-developer/gitops-generator/api/v1alpha1"
+	gitops "github.com/redhat-developer/gitops-generator/pkg"
+	component "github.com/redhat-developer/kam/pkg/pipelines/component"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/spf13/afero"
+)
+
+// AddEnv adds a new environment to the pipelines file.
+func AddEnv(o *component.GeneratorOptions, appFs afero.Afero) error {
+	bindingConfig := v1alpha1.BindingComponentConfiguration{
+		Name:     o.ComponentName,
+		Replicas: 1,
+		Resources: &corev1.ResourceRequirements{
+			Requests: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("1"),
+				corev1.ResourceMemory: resource.MustParse("256Mi"),
+			},
+		},
+		Env: nil,
+	}
+	bindingEnv := v1alpha1.Environment{
+		TypeMeta:   metav1.TypeMeta{},
+		ObjectMeta: metav1.ObjectMeta{},
+	}
+
+	e := gitops.NewCmdExecutor()
+	anyErr := gitops.GenerateOverlaysAndPush(o.Output, false, "", bindingConfig, bindingEnv, o.ApplicationName, o.EnvironmentName, "", "", e, appFs, "main", "", false, nil)
+	if anyErr != nil {
+		return fmt.Errorf("failed to create the environment :%s in component: %s: %w", o.EnvironmentName, o.ComponentName, anyErr)
+	}
+	return nil
+}

--- a/pkg/pipelines/component/environment/environment_test.go
+++ b/pkg/pipelines/component/environment/environment_test.go
@@ -1,0 +1,86 @@
+package environment
+
+import (
+	component "github.com/redhat-developer/kam/pkg/pipelines/component"
+	"github.com/redhat-developer/kam/pkg/pipelines/ioutils"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"path/filepath"
+	"testing"
+)
+
+func TestGenerateDeploymentPatch(t *testing.T) {
+	var appFs = ioutils.NewMemoryFilesystem()
+	var testPath = "/fake-path/test"
+
+	replicas := int32(1)
+	image := "container-image"
+
+	tests := []struct {
+		name             string
+		generatorOptions component.GeneratorOptions
+		wantDeployment   appsv1.Deployment
+		wantExist        bool
+	}{
+		{
+			name: "Simple component, no optional fields set",
+			generatorOptions: component.GeneratorOptions{
+				ComponentName:   "frontend",
+				ApplicationName: "testapp",
+				Output:          testPath,
+				EnvironmentName: "env-name",
+			},
+			wantExist: true,
+			wantDeployment: appsv1.Deployment{
+				TypeMeta: v1.TypeMeta{
+					Kind:       "Deployment",
+					APIVersion: "apps/v1",
+				},
+				Spec: appsv1.DeploymentSpec{
+					Replicas: &replicas,
+					Selector: &v1.LabelSelector{},
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
+								{
+									Name:  "container-image",
+									Image: image,
+									Resources: corev1.ResourceRequirements{
+										Limits: corev1.ResourceList{
+											corev1.ResourceCPU:            resource.MustParse("1"),
+											corev1.ResourceRequestsMemory: resource.MustParse("256Mi"),
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := AddEnv(&tt.generatorOptions, appFs)
+			if err != nil {
+				t.Errorf("Error adding environment. Got error: %v ", err)
+			}
+
+			pathOfEnvFolder := filepath.Join(testPath, tt.generatorOptions.ApplicationName, "components", tt.generatorOptions.ComponentName, "overlays", tt.generatorOptions.EnvironmentName)
+			envExists, _ := appFs.Exists(pathOfEnvFolder)
+			if envExists != tt.wantExist {
+				t.Errorf("Error expect file to exist: %s ", pathOfEnvFolder)
+			}
+
+			pathOfDeploymentPatchFile := filepath.Join(testPath, tt.generatorOptions.ApplicationName, "components", tt.generatorOptions.ComponentName, "overlays", tt.generatorOptions.EnvironmentName, "deployment-patch.yaml")
+			fileExists, _ := appFs.Exists(pathOfDeploymentPatchFile)
+			if fileExists != tt.wantExist {
+				t.Errorf("Error expect file to exist: %s ", pathOfDeploymentPatchFile)
+
+			}
+		})
+	}
+}

--- a/pkg/pipelines/component/types.go
+++ b/pkg/pipelines/component/types.go
@@ -13,4 +13,5 @@ type GeneratorOptions struct {
 	Overwrite            bool //
 	SaveTokenKeyRing     bool
 	PrivateRepoURLDriver string //
+	EnvironmentName      string
 }


### PR DESCRIPTION
Signed-off-by: Keith Chong <kykchong@redhat.com>

**What type of PR is this?**

/kind enhancement


**What does this PR do / why we need it**:
Add Environment Command

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes #2152

**How to test changes / Special notes to the reviewer**:
- Build kam.  Run `kam env` and `kam env add`

Notes:
- The command env will replace the current environment command (The old one).
- We still have to refactor the packages when we replace the original version of kam
